### PR TITLE
Fix PostgreSQL support

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -3,6 +3,7 @@ FROM php:8.1-%%VARIANT%%
 # Install php libs
 RUN set -ex; \
     apk add --no-cache --virtual .build-deps \
+        postgresql-dev \
         libzip-dev \
         libpng-dev \
         libjpeg-turbo-dev \
@@ -29,6 +30,7 @@ RUN set -ex; \
     docker-php-ext-configure gd --with-jpeg --with-webp; \
     \
     docker-php-ext-install \
+        pdo_pgsql \
         pdo_mysql \
         zip \
         gd \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -7,6 +7,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        libpq-dev \
         libjpeg-dev \
         libpng-dev \
         libmagickwand-dev \
@@ -39,6 +40,7 @@ RUN set -ex; \
     PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     \
     docker-php-ext-install \
+        pdo_pgsql \
         pdo_mysql \
         zip \
         gd \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -7,6 +7,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        libpq-dev \
         libjpeg-dev \
         libpng-dev \
         libmagickwand-dev \
@@ -39,6 +40,7 @@ RUN set -ex; \
     PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     \
     docker-php-ext-install \
+        pdo_pgsql \
         pdo_mysql \
         zip \
         gd \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -3,6 +3,7 @@ FROM php:8.1-fpm-alpine
 # Install php libs
 RUN set -ex; \
     apk add --no-cache --virtual .build-deps \
+        postgresql-dev \
         libzip-dev \
         libpng-dev \
         libjpeg-turbo-dev \
@@ -29,6 +30,7 @@ RUN set -ex; \
     docker-php-ext-configure gd --with-jpeg --with-webp; \
     \
     docker-php-ext-install \
+        pdo_pgsql \
         pdo_mysql \
         zip \
         gd \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -7,6 +7,7 @@ RUN set -ex; \
     \
     apt-get update; \
     apt-get install -y --no-install-recommends \
+        libpq-dev \
         libjpeg-dev \
         libpng-dev \
         libmagickwand-dev \
@@ -39,6 +40,7 @@ RUN set -ex; \
     PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
     \
     docker-php-ext-install \
+        pdo_pgsql \
         pdo_mysql \
         zip \
         gd \


### PR DESCRIPTION
PostgreSQL support is currently broken due to no system libraries or PDO drivers installed inside the Debian or Alpine images.

![espocrm-postgresql](https://github.com/espocrm/espocrm-docker/assets/202094/f663993e-9490-4237-875c-84638ce2426e)

This pull request adds the respective system libraries and PHP extensions for both distribution containers.

Debian system library: `libpq-dev`
Alpine system library: `postgresql-dev`
PHP extension: `pdo_pgsql`


