### PR TITLE
docker-entrypoint.sh working with Postgres

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -106,7 +106,7 @@ installEspocrm() {
 
     for i in {1..20}
     do
-        settingsTestResult=$(runInstallationStep "settingsTest" "hostName=${ESPOCRM_DATABASE_HOST}&dbName=${ESPOCRM_DATABASE_NAME}&dbUserName=${ESPOCRM_DATABASE_USER}&dbUserPass=${ESPOCRM_DATABASE_PASSWORD}" true 2>&1)
+        settingsTestResult=$(runInstallationStep "settingsTest" "hostName=${ESPOCRM_DATABASE_HOST}&dbName=${ESPOCRM_DATABASE_NAME}&dbUserName=${ESPOCRM_DATABASE_USER}&dbUserPass=${ESPOCRM_DATABASE_PASSWORD}&dbPlatform=${ESPOCRM_DATABASE_PLATFORM}" true 2>&1)
 
         if [[ ! "$settingsTestResult" == *"Error:"* ]]; then
             break
@@ -120,7 +120,7 @@ installEspocrm() {
         return
     fi
 
-    runInstallationStep "setupConfirmation" "host-name=${ESPOCRM_DATABASE_HOST}&db-name=${ESPOCRM_DATABASE_NAME}&db-user-name=${ESPOCRM_DATABASE_USER}&db-user-password=${ESPOCRM_DATABASE_PASSWORD}"
+    runInstallationStep "setupConfirmation" "host-name=${ESPOCRM_DATABASE_HOST}&db-name=${ESPOCRM_DATABASE_NAME}&db-user-name=${ESPOCRM_DATABASE_USER}&db-user-password=${ESPOCRM_DATABASE_PASSWORD}&db-platform=${ESPOCRM_DATABASE_PLATFORM}"
     runInstallationStep "checkPermission"
     runInstallationStep "saveSettings" "site-url=${ESPOCRM_SITE_URL}&default-permissions-user=${DEFAULT_OWNER}&default-permissions-group=${DEFAULT_GROUP}"
     runInstallationStep "buildDatabase"
@@ -179,6 +179,7 @@ else
 fi
 
 declare -A DEFAULTS=(
+    ['ESPOCRM_DATABASE_PLATFORM']='Mysql'
     ['ESPOCRM_DATABASE_HOST']='mysql'
     ['ESPOCRM_DATABASE_NAME']='espocrm'
     ['ESPOCRM_DATABASE_USER']='root'


### PR DESCRIPTION
docker-entrypoint modified to allow using Postgres instead of Mysql (but still working with Mysql as default).
Requires changes in espocrm/espocrm@5b1d1dde90dc8a44aa741d50c8bb597edbf297e1 and espocrm/espocrm-docker#31