### PR TITLE
Update to php 8.3

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,4 +1,4 @@
-FROM php:8.1-%%VARIANT%%
+FROM php:8.3-%%VARIANT%%
 
 # Install php libs
 RUN set -ex; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,4 +1,4 @@
-FROM php:8.1-%%VARIANT%%
+FROM php:8.3-%%VARIANT%%
 
 # Install php libs
 RUN set -ex; \

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.3-apache
 
 # Install php libs
 RUN set -ex; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.3-fpm-alpine
 
 # Install php libs
 RUN set -ex; \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.3-fpm
 
 # Install php libs
 RUN set -ex; \


### PR DESCRIPTION
PHP 8.3 is supported since EspoCRM 8.1. So here is the update to the dockerfiles. I testbuilt them all. All are building just fine. I tested to run apache and it works as expected.