### PR TITLE
Replace php:8.3-apache with php:8.3-apache-bookworm

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-apache
+FROM php:8.3-apache-bookworm
 
 LABEL org.opencontainers.image.source=https://github.com/espocrm/espocrm
 LABEL org.opencontainers.image.description="EspoCRM is an Open Source CRM. Try for Free."


### PR DESCRIPTION
Debian Trixie removed libc-client-dev package which breaks IMAP extension build. Switch to Bookworm base image to maintain compatibility.